### PR TITLE
Fix error on server connect

### DIFF
--- a/irccat.py
+++ b/irccat.py
@@ -89,8 +89,11 @@ def netpipe(bot, trigger):
     sock.listen(5)
 
     while True:
-        conn, addr = sock.accept()
-        data = conn.recv(1024)
+        try:
+            conn, addr = sock.accept()
+            data = conn.recv(1024)
+        except:
+            continue
 
         if not len(data.split()) >= 2:
             errmsg = 'Too short message received'


### PR DESCRIPTION
The plugin gives out an error in stdio.log whenever willie connects to a server, this patch will fix this. This is the error message:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/willie/bot.py", line 459, in call
    exit_code = func(willie, trigger)
  File "/home/noxphasma/.willie/irccat/irccat.py", line 94, in netpipe
    conn, addr = sock.accept()
  File "/usr/lib/python2.7/socket.py", line 202, in accept
    sock, addr = self._sock.accept()
timeout: timed out
```
